### PR TITLE
Fix Screenshot Reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is my Xcode 4 version of Ben Scheirman's [XCasts color theme for Xcode
 [Ryan Bates](http://railscasts.com/)' excellent [Railscasts theme for
 Textmate](http://railscasts.com/about).
 
-![Screenshot](http://github.com/bmeurer/XCasts-color-theme-for-Xcode-4/raw/master/XCasts-screenshot.png "Screenshot")
+![Screenshot](https://raw.githubusercontent.com/bmeurer/XCasts-color-theme-for-Xcode-4/master/XCasts-screenshot.png "Screenshot")
 
 # Installation
 


### PR DESCRIPTION
README.md screenshot was not displaying.  It became a link to the image with GitHub's new **raw.githubusercontent.com** domain.  I modified your README to display the image.
